### PR TITLE
SUB-4997: Add query parameters to client's query variable.

### DIFF
--- a/src/AcquiaCloudApi.php
+++ b/src/AcquiaCloudApi.php
@@ -93,7 +93,13 @@ class AcquiaCloudApi {
       }
     }
 
-    $request_options = ['query' => $valid_parameters];
+    $request_options = [];
+    // Add query parameters to $this->query
+    if (!empty($valid_parameters)) {
+      foreach ($valid_parameters as $name => $value) {
+        $this->client->addQuery($name, $value);
+      }
+    }
 
     if ($this->operations[$method]->method == 'POST' && !empty($arg[1])) {
       $request_options['json'] = $arg[1];


### PR DESCRIPTION
If `$this->query` empty in [modifyOptions](https://github.com/fiasco/cloud-api-sdk-php/blob/2.x/src/Connector/Client.php#L103), request ignores query options.